### PR TITLE
feat: bootstrap TascaFinder Expo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # TascaFinder
+
+TascaFinder é um MVP Expo + React Native focado em tascas portuguesas autênticas. Funciona offline-first com SQLite e pode ser utilizado tanto em Android como em iOS através do Expo Go.
+
+## Requisitos
+
+- Node.js LTS
+- npm ou yarn
+- Expo CLI (`npx expo`)
+
+## Scripts
+
+- `npm run dev` — inicia o Metro Bundler.
+- `npm run android` — compila e instala a app num dispositivo/emulador Android.
+- `npm run ios` — compila e instala a app num simulador iOS.
+- `npm run lint` — corre o ESLint.
+- `npm run format` — formata o código com Prettier.
+- `npm run seed` — executa o script de seed manual (útil para repor dados de teste).
+- `npm run test` — corre testes unitários simples (haversine e horário).
+
+## Permissões
+
+- Localização — utilizada para ordenar tascas por proximidade e auto-preencher formulários. O app funciona sem esta permissão, mas a ordenação recorre ao rating.
+
+## Limitações conhecidas
+
+- Não existem mapas embebidos; o botão "Abrir no mapa" apenas delega para a aplicação de mapas do sistema via deep links.
+- Imagens, ícones externos e fontes personalizadas não são suportados. Emojis e cores sólidas são usados para identidade visual.
+- Publicidade é apenas um placeholder (`<AdPlaceholder />`). No futuro poderá ser integrado AdMob.
+
+## Roadmap futuro
+
+- Sincronização com backend remoto (REST) utilizando o campo `pending_sync`.
+- Integração de autenticação real e perfis online.
+- Sistema de moderação de reviews e sugestões.
+- Monetização com SDK de anúncios.
+
+## Licença
+
+MIT

--- a/app.json
+++ b/app.json
@@ -1,0 +1,33 @@
+{
+  "expo": {
+    "name": "TascaFinder",
+    "slug": "tasca-finder",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "scheme": "tascafinder",
+    "userInterfaceStyle": "light",
+    "splash": {
+      "backgroundColor": "#0D3B66"
+    },
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#0D3B66"
+      }
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static"
+    },
+    "plugins": [
+      "expo-router",
+      "expo-secure-store",
+      "expo-sqlite"
+    ],
+    "experiments": {
+      "tsconfigPaths": true
+    }
+  }
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,25 @@
+import { Stack } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { colors } from '@/theme/colors';
+
+export default function RootLayout() {
+  return (
+    <>
+      <StatusBar style="light" backgroundColor={colors.azulejo} />
+      <Stack
+        screenOptions={{
+          headerStyle: { backgroundColor: colors.azulejo },
+          headerTintColor: colors.branco,
+          headerTitleStyle: { fontWeight: '700' },
+        }}
+      >
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen name="tasca/[id]" options={{ title: 'Detalhes da Tasca' }} />
+        <Stack.Screen name="add-tasca" options={{ title: 'Adicionar Tasca' }} />
+        <Stack.Screen name="add-review" options={{ title: 'Nova Review' }} />
+        <Stack.Screen name="roteiros/index" options={{ title: 'Roteiros 🇵🇹' }} />
+        <Stack.Screen name="perfil/index" options={{ title: 'Perfil & Sobre' }} />
+      </Stack>
+    </>
+  );
+}

--- a/app/add-review.tsx
+++ b/app/add-review.tsx
@@ -1,0 +1,223 @@
+import { useState } from 'react';
+import { useLocalSearchParams, router } from 'expo-router';
+import { Controller, useForm } from 'react-hook-form';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+import { reviewSchema } from '@/utils/validate';
+import { v4 as uuidv4 } from 'uuid';
+import { addReview } from '@/lib/repositories/reviewsRepo';
+
+const ratingFields = [
+  { name: 'comida', label: 'Comida', emoji: '🍲' },
+  { name: 'ambiente', label: 'Ambiente', emoji: '🎶' },
+  { name: 'preco_justo', label: 'Preço justo', emoji: '💶' },
+] as const;
+
+type FormValues = {
+  tasca_id: string;
+  user_nick: string;
+  comida: number;
+  ambiente: number;
+  preco_justo: number;
+  comment: string;
+};
+
+const ScoreSelector = ({ value, onChange }: { value: number; onChange: (v: number) => void }) => (
+  <View style={styles.scoreSelector}>
+    <Pressable
+      accessibilityLabel="Diminuir pontuação"
+      style={styles.scoreButton}
+      onPress={() => onChange(Math.max(0, value - 0.5))}
+    >
+      <Text style={styles.scoreButtonText}>➖</Text>
+    </Pressable>
+    <Text style={styles.scoreValue}>{value.toFixed(1)}</Text>
+    <Pressable
+      accessibilityLabel="Aumentar pontuação"
+      style={styles.scoreButton}
+      onPress={() => onChange(Math.min(5, value + 0.5))}
+    >
+      <Text style={styles.scoreButtonText}>➕</Text>
+    </Pressable>
+  </View>
+);
+
+export default function AddReviewScreen() {
+  const params = useLocalSearchParams<{ tascaId: string; name?: string }>();
+  const [submitting, setSubmitting] = useState(false);
+
+  const { control, handleSubmit } = useForm<FormValues>({
+    resolver: zodResolver(reviewSchema),
+    defaultValues: {
+      tasca_id: params.tascaId ?? '',
+      user_nick: '',
+      comida: 3,
+      ambiente: 3,
+      preco_justo: 3,
+      comment: '',
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    if (!params.tascaId) {
+      Alert.alert('Erro', 'Tasca inválida.');
+      return;
+    }
+    setSubmitting(true);
+    await addReview({
+      id: uuidv4(),
+      tasca_id: params.tascaId,
+      user_nick: values.user_nick,
+      comida: values.comida,
+      ambiente: values.ambiente,
+      preco_justo: values.preco_justo,
+      comment: values.comment ?? '',
+      created_at: new Date().toISOString(),
+      pending_sync: 1,
+    });
+    setSubmitting(false);
+    Alert.alert('Obrigado!', 'Review registada com sucesso.');
+    router.back();
+  });
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>{`✍️ Escrever review para ${params.name ?? 'tasca'}`}</Text>
+      <View style={styles.card}>
+        <Controller
+          control={control}
+          name="user_nick"
+          rules={{ required: true }}
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>O teu nome (ou alcunha)</Text>
+              <TextInput
+                value={value}
+                onChangeText={onChange}
+                placeholder="Ex.: Tasqueiro Alegre"
+                style={styles.input}
+                maxLength={40}
+              />
+            </View>
+          )}
+        />
+        {ratingFields.map((field) => (
+          <Controller
+            key={field.name}
+            control={control}
+            name={field.name}
+            render={({ field: { value, onChange } }) => (
+              <View style={styles.field}>
+                <Text style={styles.label}>{`${field.emoji} ${field.label}`}</Text>
+                <ScoreSelector value={value} onChange={onChange} />
+              </View>
+            )}
+          />
+        ))}
+        <Controller
+          control={control}
+          name="comment"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Comentário (opcional)</Text>
+              <TextInput
+                value={value}
+                onChangeText={onChange}
+                placeholder="Até 280 caracteres"
+                multiline
+                numberOfLines={4}
+                style={[styles.input, styles.textArea]}
+                maxLength={280}
+              />
+            </View>
+          )}
+        />
+        <Pressable
+          style={[styles.primaryButton, submitting && styles.disabledButton]}
+          onPress={onSubmit}
+          disabled={submitting}
+        >
+          <Text style={styles.primaryButtonText}>{submitting ? 'A guardar...' : 'Guardar review'}</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    backgroundColor: colors.bege,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.azulejo,
+    marginBottom: spacing.lg,
+  },
+  card: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.branco,
+    borderRadius: 12,
+    padding: spacing.lg,
+  },
+  field: {
+    marginBottom: spacing.lg,
+  },
+  label: {
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+    color: colors.azulejo,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    padding: spacing.md,
+    backgroundColor: colors.branco,
+    color: colors.azulejo,
+  },
+  textArea: {
+    height: 120,
+    textAlignVertical: 'top',
+  },
+  primaryButton: {
+    backgroundColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  disabledButton: {
+    opacity: 0.7,
+  },
+  primaryButtonText: {
+    color: colors.branco,
+    fontWeight: '700',
+  },
+  scoreSelector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  scoreButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: colors.azulejo,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  scoreButtonText: {
+    color: colors.branco,
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  scoreValue: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.azulejo,
+  },
+});

--- a/app/add-tasca.tsx
+++ b/app/add-tasca.tsx
@@ -1,0 +1,426 @@
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as Location from 'expo-location';
+import {
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
+import { spacing } from '@/theme/spacing';
+import { colors } from '@/theme/colors';
+import { useAppStore } from '@/store/useAppStore';
+import { addTasca } from '@/lib/repositories/tascasRepo';
+import { v4 as uuidv4 } from 'uuid';
+
+const boolFields = [
+  { name: 'has_menu_of_day', label: 'Menu do dia', emoji: '🍽️' },
+  { name: 'accepts_cards', label: 'Aceita MB', emoji: '💳' },
+  { name: 'veg_options', label: 'Opções vegetarianas', emoji: '🥦' },
+  { name: 'gluten_free', label: 'Opções sem glúten', emoji: '🌾' },
+] as const;
+
+type BoolFieldName = (typeof boolFields)[number]['name'];
+
+const scheduleTextExample = `mon:12:00-15:00,19:00-22:00\ntue:12:00-15:00,19:00-22:00\nwed:12:00-15:00,19:00-22:00\nthu:12:00-15:00,19:00-22:00\nfri:12:00-15:00,19:00-23:00\nsat:12:30-16:00,19:00-23:00\nsun:`;
+
+const formSchema = z.object({
+  name: z.string().min(3),
+  address: z.string().min(5),
+  city: z.string().min(2),
+  lat: z.coerce.number().min(-90).max(90),
+  lng: z.coerce.number().min(-180).max(180),
+  price_level: z.coerce.number().int().min(1).max(3),
+  has_menu_of_day: z.boolean(),
+  accepts_cards: z.boolean(),
+  veg_options: z.boolean(),
+  gluten_free: z.boolean(),
+  tags_csv: z.string().optional().default(''),
+  phone: z.string().optional().nullable(),
+  website: z.string().url().optional().or(z.literal('')).nullable(),
+  menu_url: z.string().url().optional().or(z.literal('')).nullable(),
+  schedule_text: z.string().min(0),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+const parseScheduleText = (input: string) => {
+  const schedule: Record<string, [string, string][]> = {};
+  input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const [day, ranges] = line.split(':');
+      if (!day) return;
+      const normalizedDay = day.slice(0, 3).toLowerCase();
+      schedule[normalizedDay] = (ranges ?? '')
+        .split(',')
+        .map((range) => range.trim())
+        .filter(Boolean)
+        .map((range) => {
+          const [start, end] = range.split('-').map((value) => value.trim());
+          if (!start || !end) {
+            return null;
+          }
+          return [start, end] as [string, string];
+        })
+        .filter((slot): slot is [string, string] => Array.isArray(slot));
+    });
+  return schedule;
+};
+
+export default function AddTascaScreen() {
+  const { location, setLocation, setPermissionStatus } = useAppStore();
+  const [submitting, setSubmitting] = useState(false);
+
+  const { control, handleSubmit, setValue } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      address: '',
+      city: '',
+      lat: location.coords?.lat ?? 0,
+      lng: location.coords?.lng ?? 0,
+      price_level: 1,
+      has_menu_of_day: true,
+      accepts_cards: true,
+      veg_options: false,
+      gluten_free: false,
+      tags_csv: '',
+      phone: '',
+      website: '',
+      menu_url: '',
+      schedule_text: scheduleTextExample,
+    },
+  });
+
+  const requestLocation = async () => {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    setPermissionStatus(status === 'granted' ? 'granted' : 'denied');
+    if (status !== 'granted') {
+      Alert.alert('Permissão necessária', 'Não foi possível obter localização.');
+      return;
+    }
+    const loc = await Location.getCurrentPositionAsync({});
+    const coords = { lat: loc.coords.latitude, lng: loc.coords.longitude };
+    setLocation(coords);
+    setValue('lat', coords.lat);
+    setValue('lng', coords.lng);
+  };
+
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitting(true);
+    const schedule = parseScheduleText(values.schedule_text || scheduleTextExample);
+    await addTasca({
+      id: uuidv4(),
+      name: values.name,
+      address: values.address,
+      city: values.city,
+      lat: values.lat,
+      lng: values.lng,
+      price_level: values.price_level,
+      has_menu_of_day: values.has_menu_of_day ? 1 : 0,
+      accepts_cards: values.accepts_cards ? 1 : 0,
+      veg_options: values.veg_options ? 1 : 0,
+      gluten_free: values.gluten_free ? 1 : 0,
+      tags_csv: values.tags_csv ?? '',
+      phone: values.phone || null,
+      website: values.website || null,
+      menu_url: values.menu_url || null,
+      schedule_json: JSON.stringify(schedule),
+      pending_sync: 1,
+    });
+    setSubmitting(false);
+    Alert.alert('Obrigado!', 'Tasca adicionada 👏');
+    router.replace('/');
+  });
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>➕ Adiciona uma tasca autêntica</Text>
+      <View style={styles.card}>
+        <Controller
+          control={control}
+          name="name"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Nome</Text>
+              <TextInput style={styles.input} value={value} onChangeText={onChange} placeholder="Ex.: Tasca do Zé" />
+            </View>
+          )}
+        />
+        <Controller
+          control={control}
+          name="address"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Morada</Text>
+              <TextInput style={styles.input} value={value} onChangeText={onChange} placeholder="Rua..." />
+            </View>
+          )}
+        />
+        <Controller
+          control={control}
+          name="city"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Cidade</Text>
+              <TextInput style={styles.input} value={value} onChangeText={onChange} placeholder="Lisboa" />
+            </View>
+          )}
+        />
+        <View style={styles.inlineFields}>
+          <Controller
+            control={control}
+            name="lat"
+            render={({ field: { value, onChange } }) => (
+              <View style={styles.inlineField}>
+                <Text style={styles.label}>Latitude</Text>
+                <TextInput style={styles.input} value={String(value)} onChangeText={onChange} keyboardType="decimal-pad" />
+              </View>
+            )}
+          />
+          <Controller
+            control={control}
+            name="lng"
+            render={({ field: { value, onChange } }) => (
+              <View style={styles.inlineField}>
+                <Text style={styles.label}>Longitude</Text>
+                <TextInput style={styles.input} value={String(value)} onChangeText={onChange} keyboardType="decimal-pad" />
+              </View>
+            )}
+          />
+        </View>
+        <Pressable style={styles.secondaryButton} onPress={requestLocation}>
+          <Text style={styles.secondaryButtonText}>📍 Usar minha localização</Text>
+        </Pressable>
+        <Text style={[styles.label, styles.priceLabel]}>Nível de preço</Text>
+        <Controller
+          control={control}
+          name="price_level"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.priceRow}>
+              {[1, 2, 3].map((level) => (
+                <Pressable
+                  key={level}
+                  onPress={() => onChange(level)}
+                  style={[styles.priceChip, value === level && styles.priceChipActive]}
+                >
+                  <Text style={[styles.priceChipText, value === level && styles.priceChipTextActive]}>
+                    {'€'.repeat(level)}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          )}
+        />
+        {boolFields.map((field) => (
+          <Controller
+            key={field.name}
+            control={control}
+            name={field.name as BoolFieldName}
+            render={({ field: { value, onChange } }) => (
+              <Pressable onPress={() => onChange(!value)} style={[styles.boolChip, value && styles.boolChipActive]}>
+                <Text style={[styles.boolChipText, value && styles.boolChipTextActive]}>{`${field.emoji} ${field.label}`}</Text>
+              </Pressable>
+            )}
+          />
+        ))}
+        <Controller
+          control={control}
+          name="tags_csv"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Tags (separadas por vírgula)</Text>
+              <TextInput
+                style={styles.input}
+                value={value ?? ''}
+                onChangeText={onChange}
+                placeholder="bacalhau, petiscos, caldo verde"
+              />
+            </View>
+          )}
+        />
+        <Controller
+          control={control}
+          name="phone"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Contacto telefónico</Text>
+              <TextInput style={styles.input} value={value ?? ''} onChangeText={onChange} keyboardType="phone-pad" />
+            </View>
+          )}
+        />
+        <Controller
+          control={control}
+          name="website"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Website</Text>
+              <TextInput style={styles.input} value={value ?? ''} onChangeText={onChange} placeholder="https://" />
+            </View>
+          )}
+        />
+        <Controller
+          control={control}
+          name="menu_url"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Menu online (opcional)</Text>
+              <TextInput style={styles.input} value={value ?? ''} onChangeText={onChange} placeholder="https://" />
+            </View>
+          )}
+        />
+        <Controller
+          control={control}
+          name="schedule_text"
+          render={({ field: { value, onChange } }) => (
+            <View style={styles.field}>
+              <Text style={styles.label}>Horário por dia (formato mon:12:00-15:00)</Text>
+              <TextInput
+                style={[styles.input, styles.textArea]}
+                value={value}
+                onChangeText={onChange}
+                multiline
+                numberOfLines={6}
+              />
+            </View>
+          )}
+        />
+        <Pressable
+          style={[styles.primaryButton, submitting && styles.disabledButton]}
+          onPress={onSubmit}
+          disabled={submitting}
+        >
+          <Text style={styles.primaryButtonText}>{submitting ? 'A guardar...' : 'Guardar Tasca'}</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    backgroundColor: colors.bege,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.azulejo,
+    marginBottom: spacing.lg,
+  },
+  card: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.branco,
+    borderRadius: 12,
+    padding: spacing.lg,
+  },
+  field: {
+    marginBottom: spacing.lg,
+  },
+  label: {
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+    color: colors.azulejo,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    padding: spacing.md,
+    backgroundColor: colors.branco,
+    color: colors.azulejo,
+  },
+  inlineFields: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  inlineField: {
+    flex: 1,
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    backgroundColor: colors.branco,
+    marginBottom: spacing.lg,
+  },
+  secondaryButtonText: {
+    color: colors.azulejo,
+    fontWeight: '700',
+  },
+  priceLabel: {
+    marginBottom: spacing.sm,
+  },
+  priceRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  priceChip: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    backgroundColor: colors.branco,
+  },
+  priceChipActive: {
+    backgroundColor: colors.azulejo,
+  },
+  priceChipText: {
+    color: colors.azulejo,
+    fontWeight: '700',
+  },
+  priceChipTextActive: {
+    color: colors.branco,
+  },
+  boolChip: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.branco,
+  },
+  boolChipActive: {
+    backgroundColor: colors.azulejo,
+  },
+  boolChipText: {
+    color: colors.azulejo,
+    fontWeight: '700',
+  },
+  boolChipTextActive: {
+    color: colors.branco,
+  },
+  textArea: {
+    height: 140,
+    textAlignVertical: 'top',
+  },
+  primaryButton: {
+    backgroundColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  disabledButton: {
+    opacity: 0.7,
+  },
+  primaryButtonText: {
+    color: colors.branco,
+    fontWeight: '700',
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react';
+import { router } from 'expo-router';
+import * as Location from 'expo-location';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  Pressable,
+} from 'react-native';
+import { useAppStore } from '@/store/useAppStore';
+import { listTascas, TascaWithScore } from '@/lib/repositories/tascasRepo';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+import { TileHeader } from '@/components/TileHeader';
+import { TascaCard } from '@/components/TascaCard';
+import { Chip } from '@/components/Chip';
+import { EmptyState } from '@/components/EmptyState';
+import { AdPlaceholder } from '@/components/AdPlaceholder';
+
+const quickFilters = [
+  { key: 'barato', label: '€ Barato', icon: '💶' },
+  { key: 'menu', label: 'Menu do Dia', icon: '🍽️' },
+  { key: 'petiscos', label: 'Petiscos', icon: '🥘' },
+  { key: 'comidaCaseira', label: 'Comida Caseira', icon: '🍲' },
+  { key: 'abertoAgora', label: 'Aberto Agora', icon: '🕰️' },
+] as const;
+
+export default function HomeScreen() {
+  const { filters, toggleFilter, query, setQuery, location, setLocation, setPermissionStatus } =
+    useAppStore();
+  const [loading, setLoading] = useState(true);
+  const [tascas, setTascas] = useState<TascaWithScore[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadTascas = async () => {
+    setLoading(true);
+    const items = await listTascas({
+      query,
+      filters,
+      location: location.coords,
+    });
+    setTascas(items);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadTascas();
+  }, [filters, query, location.coords]);
+
+  const handleUseLocation = async () => {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    setPermissionStatus(status === 'granted' ? 'granted' : 'denied');
+    if (status !== 'granted') {
+      Alert.alert('Permissão necessária', 'Precisamos da tua localização para ordenar por distância.');
+      return;
+    }
+    const loc = await Location.getCurrentPositionAsync({});
+    setLocation({ lat: loc.coords.latitude, lng: loc.coords.longitude });
+  };
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadTascas();
+    setRefreshing(false);
+  };
+
+  const renderItem = ({ item }: { item: TascaWithScore }) => (
+    <TascaCard
+      {...item}
+      onPress={() => router.push({ pathname: '/tasca/[id]', params: { id: item.id } })}
+    />
+  );
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <FlatList
+        data={tascas}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListHeaderComponent={
+          <View style={styles.headerContainer}>
+            <TileHeader title="TascaFinder" subtitle="O guia de tascas portuguesas 🍽️" />
+            <View style={styles.controls}>
+              <TextInput
+                value={query}
+                onChangeText={setQuery}
+                placeholder="🔎 Pesquisa por nome, bairro ou cidade"
+                placeholderTextColor={colors.cinzaMedio}
+                style={styles.search}
+                accessibilityLabel="Campo de pesquisa"
+              />
+              <Pressable style={styles.locationButton} onPress={handleUseLocation}>
+                <Text style={styles.locationButtonText}>📍 Usar minha localização</Text>
+              </Pressable>
+            </View>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filtersRow}>
+              {quickFilters.map((filter) => (
+                <Chip
+                  key={filter.key}
+                  label={filter.label}
+                  icon={filter.icon}
+                  active={filters[filter.key]}
+                  onPress={() => toggleFilter(filter.key)}
+                />
+              ))}
+            </ScrollView>
+            <Pressable
+              style={styles.secondaryButton}
+              onPress={() => router.push('/add-tasca')}
+              accessibilityLabel="Adicionar nova tasca"
+            >
+              <Text style={styles.secondaryButtonText}>➕ Adicionar Tasca</Text>
+            </Pressable>
+            <Pressable
+              style={styles.secondaryButton}
+              onPress={() => router.push('/roteiros')}
+              accessibilityLabel="Abrir roteiros turísticos"
+            >
+              <Text style={styles.secondaryButtonText}>🇵🇹 Ver Roteiros</Text>
+            </Pressable>
+            <AdPlaceholder />
+          </View>
+        }
+        ListEmptyComponent={
+          loading ? (
+            <ActivityIndicator color={colors.azulejo} />
+          ) : (
+            <EmptyState title="Sem tascas" description="Experimenta ajustar filtros ou adicionar uma nova tasca." />
+          )
+        }
+        contentContainerStyle={styles.listContent}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.bege,
+  },
+  headerContainer: {
+    padding: spacing.lg,
+    backgroundColor: colors.bege,
+  },
+  controls: {
+    marginTop: spacing.lg,
+  },
+  search: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.branco,
+    borderRadius: 12,
+    padding: spacing.md,
+    fontSize: 16,
+    color: colors.azulejo,
+  },
+  locationButton: {
+    marginTop: spacing.sm,
+    backgroundColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    alignItems: 'center',
+  },
+  locationButtonText: {
+    color: colors.branco,
+    fontWeight: '700',
+  },
+  filtersRow: {
+    marginTop: spacing.lg,
+  },
+  secondaryButton: {
+    marginTop: spacing.sm,
+    paddingVertical: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    alignItems: 'center',
+    backgroundColor: colors.branco,
+  },
+  secondaryButtonText: {
+    color: colors.azulejo,
+    fontWeight: '700',
+  },
+  listContent: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xxl,
+  },
+});

--- a/app/perfil/index.tsx
+++ b/app/perfil/index.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import * as SecureStore from 'expo-secure-store';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+import { AdPlaceholder } from '@/components/AdPlaceholder';
+
+const NICKNAME_KEY = 'tasca_nickname';
+
+export default function PerfilScreen() {
+  const [nick, setNick] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const stored = await SecureStore.getItemAsync(NICKNAME_KEY);
+      if (stored) {
+        setNick(stored);
+      }
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  const saveNick = async () => {
+    await SecureStore.setItemAsync(NICKNAME_KEY, nick);
+    Alert.alert('Guardado', 'Perfil atualizado com sucesso.');
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>👤 O teu perfil offline</Text>
+        <Text style={styles.description}>
+          Guarda um nickname para assinares reviews e sugestões mesmo sem ligação à internet.
+        </Text>
+        <TextInput
+          value={nick}
+          onChangeText={setNick}
+          style={styles.input}
+          placeholder="Ex.: Tasqueiro Alegre"
+        />
+        <Pressable style={styles.primaryButton} onPress={saveNick} disabled={loading}>
+          <Text style={styles.primaryButtonText}>💾 Guardar</Text>
+        </Pressable>
+      </View>
+      <AdPlaceholder />
+      <View style={styles.card}>
+        <Text style={styles.title}>ℹ️ Sobre o TascaFinder</Text>
+        <Text style={styles.paragraph}>
+          TascaFinder é um guia independente dedicado a preservar e divulgar as tascas portuguesas clássicas. É um projeto
+          offline-first, pensado para funcionar em viagem e em locais com rede limitada.
+        </Text>
+        <Text style={styles.subtitle}>Como classificamos</Text>
+        <Text style={styles.paragraph}>
+          Cada tasca recebe notas de 0 a 5 em três dimensões: Comida (50%), Ambiente (30%) e Preço Justo (20%). A média
+          ponderada cria o score principal. Reviews novas recalculam automaticamente estas métricas.
+        </Text>
+        <Text style={styles.subtitle}>Sugere uma tasca</Text>
+        <Text style={styles.paragraph}>
+          Se conheces uma tasca que merece destaque, adiciona-a através do formulário "Adicionar Tasca". Fica marcada como
+          pendente de sincronização até existir ligação a um backend.
+        </Text>
+        <Text style={styles.subtitle}>Contacta-nos</Text>
+        <Text style={styles.paragraph}>
+          Envia um email para ola@tascafinder.pt com sugestões, correções ou parcerias. Adoramos ouvir histórias de tascas!
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    backgroundColor: colors.bege,
+    gap: spacing.lg,
+  },
+  card: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.branco,
+    borderRadius: 12,
+    padding: spacing.lg,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.azulejo,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.azulejo,
+    marginTop: spacing.lg,
+    marginBottom: spacing.xs,
+  },
+  description: {
+    color: colors.cinzaTexto,
+    marginBottom: spacing.md,
+  },
+  paragraph: {
+    color: colors.cinzaTexto,
+    marginBottom: spacing.sm,
+    lineHeight: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    padding: spacing.md,
+    backgroundColor: colors.branco,
+    color: colors.azulejo,
+  },
+  primaryButton: {
+    marginTop: spacing.md,
+    backgroundColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: colors.branco,
+    fontWeight: '700',
+  },
+});

--- a/app/roteiros/index.tsx
+++ b/app/roteiros/index.tsx
@@ -1,0 +1,94 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+import { Chip } from '@/components/Chip';
+
+const itineraries = [
+  {
+    title: 'Lisboa em 24h (Baixa/Mouraria/Alfama)',
+    emoji: '⛵',
+    tips: 'Começa com um café na Baixa, sobe à Mouraria ao almoço e termina com fado na Alfama.',
+    stops: [
+      { name: 'A Tasquinha do Fado', tip: 'Fado ao vivo e bacalhau à lagareiro.' },
+      { name: 'Casa das Iscas', tip: 'Menu do dia económico com iscas inesquecíveis.' },
+      { name: 'Zé da Mouraria', tip: 'Bifes gigantes e ambiente 100% tasca.' },
+      { name: 'Adega dos Arcos', tip: 'Chouriço assado e vinho da casa.' },
+      { name: 'Taberna da Rua das Flores', tip: 'Petiscos autorais com toque caseiro.' },
+    ],
+  },
+  {
+    title: 'Porto Clássico (Ribeira/Miragaia)',
+    emoji: '🚢',
+    tips: 'Ribeira para vistas do Douro, finaliza na Francesinha acompanhada por fino gelado.',
+    stops: [
+      { name: 'Adega São Nicolau', tip: 'Tripas e bacalhau com sabor a Norte.' },
+      { name: 'Taberna Santo António', tip: 'Menu do dia com vista para o Douro.' },
+      { name: 'Tasquinha do Olival', tip: 'Petiscos para partilhar e vinho do Porto.' },
+      { name: 'Casa Guedes', tip: 'Sandes de pernil com queijo da Serra.' },
+      { name: 'Café Santiago', tip: 'Francesinha clássica para fechar a noite.' },
+    ],
+  },
+  {
+    title: 'Braga/Guimarães Tradicional',
+    emoji: '🏰',
+    tips: 'Roteiro entre o Minho e a história, perfeito para petiscos de tarde.',
+    stops: [
+      { name: 'Cantinho Minhoto', tip: 'Papas de sarrabulho e rojões.' },
+      { name: 'Tasca da Sé', tip: 'Pataniscas e vinho verde fresco.' },
+      { name: 'Taberna Tio Júlio', tip: 'Caldo verde e rojões à moda do Minho.' },
+      { name: 'Adega Típica de Guimarães', tip: 'Arroz de cabidela e enchidos artesanais.' },
+      { name: 'Casa Borges', tip: 'Doces conventuais para sobremesa.' },
+    ],
+  },
+];
+
+export default function RoteirosScreen() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {itineraries.map((itinerary) => (
+        <View key={itinerary.title} style={styles.card}>
+          <Text style={styles.title}>{`${itinerary.emoji} ${itinerary.title}`}</Text>
+          <Text style={styles.tip}>{itinerary.tips}</Text>
+          {itinerary.stops.map((stop, index) => (
+            <View key={stop.name} style={styles.stopRow}>
+              <Chip label={`${index + 1}. ${stop.name}`} icon="🧭" />
+              <Text style={styles.stopTip}>{stop.tip}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    backgroundColor: colors.bege,
+    gap: spacing.lg,
+  },
+  card: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.branco,
+    borderRadius: 12,
+    padding: spacing.lg,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.azulejo,
+  },
+  tip: {
+    color: colors.cinzaTexto,
+    marginTop: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  stopRow: {
+    marginBottom: spacing.sm,
+  },
+  stopTip: {
+    marginTop: spacing.xs,
+    color: colors.cinzaMedio,
+  },
+});

--- a/app/tasca/[id].tsx
+++ b/app/tasca/[id].tsx
@@ -1,0 +1,303 @@
+import { useEffect, useState } from 'react';
+import { useLocalSearchParams, router } from 'expo-router';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  Pressable,
+} from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+import { shadows } from '@/theme/shadows';
+import { getTascaById } from '@/lib/repositories/tascasRepo';
+import { useAppStore } from '@/store/useAppStore';
+import { AdPlaceholder } from '@/components/AdPlaceholder';
+import { Chip } from '@/components/Chip';
+import { Rating } from '@/components/Rating';
+import { EmptyState } from '@/components/EmptyState';
+import { formatPriceLevel } from '@/utils/format';
+import { openInMaps } from '@/lib/geo';
+import { formatScheduleRange, todaysSchedule } from '@/lib/schedule';
+
+const flags = [
+  { key: 'has_menu_of_day', label: 'Menu do dia', emoji: '🍲' },
+  { key: 'accepts_cards', label: 'Aceita MB', emoji: '💳' },
+  { key: 'veg_options', label: 'Vegetariano', emoji: '🥦' },
+  { key: 'gluten_free', label: 'Gluten-free', emoji: '🌾' },
+] as const;
+
+export default function TascaDetail() {
+  const params = useLocalSearchParams<{ id: string }>();
+  const { location } = useAppStore();
+  const [loading, setLoading] = useState(true);
+  const [tasca, setTasca] = useState<any | null>(null);
+
+  useEffect(() => {
+    if (!params.id) return;
+    const fetchData = async () => {
+      setLoading(true);
+      const result = await getTascaById(params.id, location.coords);
+      setTasca(result);
+      setLoading(false);
+    };
+    fetchData();
+  }, [params.id, location.coords]);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={colors.azulejo} />
+      </View>
+    );
+  }
+
+  if (!tasca) {
+    return <EmptyState title="Tasca não encontrada" description="Volta atrás e escolhe outra tasca." emoji="❌" />;
+  }
+
+  const schedule = JSON.parse(tasca.schedule_json);
+  const todayRange = todaysSchedule(schedule);
+
+  const handleCall = () => {
+    if (!tasca.phone) {
+      Alert.alert('Sem contacto', 'Esta tasca ainda não tem número associado.');
+      return;
+    }
+    Linking.openURL(`tel:${tasca.phone}`);
+  };
+
+  const handleOpenWebsite = (url?: string | null) => {
+    if (!url) {
+      Alert.alert('Sem site', 'Ainda não temos website associado.');
+      return;
+    }
+    Linking.openURL(url);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>{`🥘 ${tasca.name}`}</Text>
+        <Text style={styles.subtitle}>{`${tasca.address}, ${tasca.city}`}</Text>
+        <View style={styles.metrics}>
+          <Rating label="Score" value={tasca.score} />
+          <Rating label="Comida" value={tasca.comida} />
+          <Rating label="Ambiente" value={tasca.ambiente} />
+          <Rating label="Preço" value={tasca.preco_justo} />
+        </View>
+        <Text style={styles.sectionTitle}>Informação</Text>
+        <View style={styles.infoRow}>
+          <Text style={styles.infoLabel}>Endereço</Text>
+          <Text style={styles.infoValue}>{tasca.address}</Text>
+          <Pressable style={styles.infoButton} onPress={() => openInMaps(tasca.lat, tasca.lng, tasca.name)}>
+            <Text style={styles.infoButtonText}>🧭 Abrir no mapa</Text>
+          </Pressable>
+        </View>
+        <View style={styles.infoRow}>
+          <Text style={styles.infoLabel}>Contacto</Text>
+          <Text style={styles.infoValue}>{tasca.phone ?? '—'}</Text>
+          <Pressable style={styles.infoButton} onPress={handleCall}>
+            <Text style={styles.infoButtonText}>📞 Ligar</Text>
+          </Pressable>
+        </View>
+        <View style={styles.infoRow}>
+          <Text style={styles.infoLabel}>Website</Text>
+          <Text style={styles.infoValue}>{tasca.website ?? '—'}</Text>
+          <Pressable style={styles.infoButton} onPress={() => handleOpenWebsite(tasca.website)}>
+            <Text style={styles.infoButtonText}>🌐 Abrir site</Text>
+          </Pressable>
+        </View>
+        <View style={styles.infoRow}>
+          <Text style={styles.infoLabel}>Menu online</Text>
+          <Text style={styles.infoValue}>{tasca.menu_url ?? '—'}</Text>
+          <Pressable style={styles.infoButton} onPress={() => handleOpenWebsite(tasca.menu_url)}>
+            <Text style={styles.infoButtonText}>📜 Ver menu</Text>
+          </Pressable>
+        </View>
+        <View style={styles.infoRow}>
+          <Text style={styles.infoLabel}>Preço</Text>
+          <Text style={styles.infoValue}>{formatPriceLevel(tasca.price_level as 1 | 2 | 3)}</Text>
+        </View>
+        <View style={styles.infoRow}>
+          <Text style={styles.infoLabel}>Horário hoje</Text>
+          <Text style={styles.infoValue}>
+            {todayRange.length > 0 ? formatScheduleRange(todayRange) : 'Fechado'}
+          </Text>
+        </View>
+        <View style={styles.flagRow}>
+          {flags.map((flag) =>
+            tasca[flag.key] ? (
+              <Chip key={flag.key} label={flag.label} icon={flag.emoji} />
+            ) : null
+          )}
+        </View>
+        <Text style={styles.sectionTitle}>Especialidades</Text>
+        <View style={styles.tagsRow}>
+          {tasca.tags_csv
+            .split(',')
+            .map((tag: string) => tag.trim())
+            .filter(Boolean)
+            .map((tag: string) => (
+              <Chip key={tag} label={tag} icon="🍷" />
+            ))}
+        </View>
+        <Pressable
+          style={styles.primaryButton}
+          onPress={() =>
+            router.push({ pathname: '/add-review', params: { tascaId: tasca.id, name: tasca.name } })
+          }
+        >
+          <Text style={styles.primaryButtonText}>✍️ Escrever review</Text>
+        </Pressable>
+        <Pressable
+          style={styles.secondaryButton}
+          onPress={() => Alert.alert('Sugestão enviada', 'Obrigado pela tua sugestão!')}
+        >
+          <Text style={styles.secondaryButtonText}>🛠️ Sugerir correção</Text>
+        </Pressable>
+      </View>
+
+      <AdPlaceholder />
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Reviews ({tasca.reviews.length})</Text>
+        {tasca.reviews.length === 0 ? (
+          <EmptyState title="Sem reviews" description="Sê o primeiro a partilhar a tua experiência." emoji="📝" />
+        ) : (
+          tasca.reviews.map((review: any) => (
+            <View key={review.id} style={styles.reviewCard}>
+              <Text style={styles.reviewHeader}>{`${review.user_nick} • ${new Date(
+                review.created_at
+              ).toLocaleDateString()}`}</Text>
+              <Text style={styles.reviewScores}>{`Comida ${review.comida.toFixed(1)} ⭐  Ambiente ${review.ambiente.toFixed(
+                1
+              )} ⭐  Preço ${review.preco_justo.toFixed(1)} ⭐`}</Text>
+              <Text style={styles.reviewComment}>{review.comment}</Text>
+            </View>
+          ))
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    backgroundColor: colors.bege,
+  },
+  card: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.branco,
+    borderRadius: 12,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+    ...shadows.card,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.azulejo,
+  },
+  subtitle: {
+    color: colors.cinzaMedio,
+    marginTop: spacing.xs,
+    marginBottom: spacing.md,
+  },
+  metrics: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.azulejo,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
+  },
+  infoRow: {
+    marginBottom: spacing.sm,
+  },
+  infoLabel: {
+    fontWeight: '700',
+    color: colors.azulejo,
+  },
+  infoValue: {
+    color: colors.cinzaTexto,
+    marginTop: spacing.xs,
+  },
+  infoButton: {
+    marginTop: spacing.xs,
+    alignSelf: 'flex-start',
+    backgroundColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+  },
+  infoButtonText: {
+    color: colors.branco,
+    fontWeight: '700',
+  },
+  flagRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  primaryButton: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: colors.branco,
+    fontWeight: '700',
+  },
+  secondaryButton: {
+    marginTop: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 12,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    backgroundColor: colors.branco,
+  },
+  secondaryButtonText: {
+    color: colors.azulejo,
+    fontWeight: '700',
+  },
+  reviewCard: {
+    borderTopWidth: 1,
+    borderTopColor: colors.cinzaClaro,
+    paddingVertical: spacing.md,
+  },
+  reviewHeader: {
+    color: colors.azulejo,
+    fontWeight: '700',
+  },
+  reviewScores: {
+    color: colors.cinzaMedio,
+    marginTop: spacing.xs,
+  },
+  reviewComment: {
+    color: colors.cinzaTexto,
+    marginTop: spacing.xs,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
+  };
+};

--- a/components/AdPlaceholder.tsx
+++ b/components/AdPlaceholder.tsx
@@ -1,0 +1,28 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+
+export const AdPlaceholder = () => {
+  return (
+    <View style={styles.container} accessibilityRole="text">
+      <Text style={styles.text}>Espaço de Anúncio — 🍷 Divulga a tua tasca aqui</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: colors.vinho,
+    borderRadius: 12,
+    padding: spacing.lg,
+    marginVertical: spacing.lg,
+    backgroundColor: colors.branco,
+  },
+  text: {
+    color: colors.vinho,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+});

--- a/components/Chip.tsx
+++ b/components/Chip.tsx
@@ -1,0 +1,57 @@
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+
+interface ChipProps {
+  label: string;
+  icon?: string;
+  active?: boolean;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+}
+
+export const Chip = ({ label, icon, active = false, onPress, accessibilityLabel }: ChipProps) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={accessibilityLabel ?? label}
+      style={({ pressed }) => [
+        styles.container,
+        active && styles.active,
+        pressed && styles.pressed,
+      ]}
+    >
+      <Text style={[styles.text, active && styles.textActive]}>{`${icon ? `${icon} ` : ''}${label}`}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    borderColor: colors.azulejo,
+    borderRadius: 999,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    marginRight: spacing.sm,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.bege,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  active: {
+    backgroundColor: colors.azulejo,
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+  text: {
+    color: colors.azulejo,
+    fontWeight: '600',
+  },
+  textActive: {
+    color: colors.branco,
+  },
+});

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  emoji?: string;
+}
+
+export const EmptyState = ({ title, description, emoji = '🧭' }: EmptyStateProps) => (
+  <View style={styles.container}>
+    <Text style={styles.emoji}>{emoji}</Text>
+    <Text style={styles.title}>{title}</Text>
+    {description ? <Text style={styles.description}>{description}</Text> : null}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  emoji: {
+    fontSize: 40,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.azulejo,
+    marginTop: spacing.sm,
+  },
+  description: {
+    textAlign: 'center',
+    marginTop: spacing.xs,
+    color: colors.cinzaMedio,
+  },
+});

--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -1,0 +1,37 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+
+interface RatingProps {
+  label: string;
+  value: number;
+}
+
+export const Rating = ({ label, value }: RatingProps) => {
+  const stars = Math.round(value);
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.value} accessibilityLabel={`${label} ${value.toFixed(1)} em 5`}>
+        {'⭐'.repeat(stars)} {value.toFixed(1)}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: spacing.xs,
+  },
+  label: {
+    color: colors.cinzaMedio,
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  value: {
+    color: colors.azulejo,
+    fontWeight: '700',
+    fontSize: 16,
+  },
+});

--- a/components/TascaCard.tsx
+++ b/components/TascaCard.tsx
@@ -1,0 +1,117 @@
+import { ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+import { shadows } from '@/theme/shadows';
+import { formatDistance, formatPriceLevel, formatScore } from '@/utils/format';
+import { Chip } from './Chip';
+
+interface TascaCardProps {
+  name: string;
+  city: string;
+  address: string;
+  score: number;
+  comida: number;
+  ambiente: number;
+  preco_justo: number;
+  price_level: number;
+  tags_csv: string;
+  distanceKm?: number;
+  onPress?: () => void;
+  footer?: ReactNode;
+}
+
+export const TascaCard = ({
+  name,
+  city,
+  address,
+  score,
+  comida,
+  ambiente,
+  preco_justo,
+  price_level,
+  tags_csv,
+  distanceKm,
+  onPress,
+  footer,
+}: TascaCardProps) => {
+  const tags = tags_csv.split(',').map((tag) => tag.trim()).filter(Boolean);
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.container, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Abrir detalhes da tasca ${name}`}
+    >
+      <View style={styles.header}>
+        <Text style={styles.name}>{`🍽️ ${name}`}</Text>
+        <Text style={styles.city}>{`${city} • ${address}`}</Text>
+      </View>
+      <View style={styles.scoreRow}>
+        <Text style={styles.scoreBadge}>{`⭐ ${formatScore(score)}`}</Text>
+        <Text style={styles.scoreDetail}>{`Comida ${comida.toFixed(1)} • Ambiente ${ambiente.toFixed(1)} • Preço ${preco_justo.toFixed(1)}`}</Text>
+      </View>
+      <View style={styles.metaRow}>
+        <Chip label={formatPriceLevel(price_level as 1 | 2 | 3)} icon="💶" />
+        {distanceKm !== undefined ? (
+          <Chip label={formatDistance(distanceKm)} icon="🧭" />
+        ) : null}
+      </View>
+      <View style={styles.tagsRow}>
+        {tags.map((tag) => (
+          <Chip key={tag} label={tag} icon="🥘" />
+        ))}
+      </View>
+      {footer}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.bege,
+    borderRadius: 12,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+    ...shadows.card,
+  },
+  pressed: {
+    opacity: 0.9,
+  },
+  header: {
+    marginBottom: spacing.sm,
+  },
+  name: {
+    color: colors.azulejo,
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  city: {
+    color: colors.cinzaMedio,
+    fontSize: 14,
+    marginTop: spacing.xs,
+  },
+  scoreRow: {
+    marginBottom: spacing.sm,
+  },
+  scoreBadge: {
+    color: colors.azulejo,
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  scoreDetail: {
+    color: colors.cinzaMedio,
+    marginTop: spacing.xs,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: spacing.sm,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+});

--- a/components/TileHeader.tsx
+++ b/components/TileHeader.tsx
@@ -1,0 +1,60 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { ReactNode } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/colors';
+import { spacing } from '@/theme/spacing';
+
+interface TileHeaderProps {
+  title: string;
+  subtitle?: string;
+  rightContent?: ReactNode;
+}
+
+export const TileHeader = ({ title, subtitle, rightContent }: TileHeaderProps) => {
+  return (
+    <View style={styles.container}>
+      <LinearGradient
+        colors={[colors.azulejo, '#17497D']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.gradient}
+      >
+        <Text accessibilityRole="header" style={styles.title}>
+          {title}
+        </Text>
+        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+      </LinearGradient>
+      {rightContent ? <View style={styles.right}>{rightContent}</View> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  gradient: {
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.xl,
+  },
+  title: {
+    color: colors.branco,
+    fontSize: 24,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: colors.bege,
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: spacing.xs,
+  },
+  right: {
+    position: 'absolute',
+    top: spacing.sm,
+    right: spacing.sm,
+  },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,67 @@
+import * as SQLite from 'expo-sqlite';
+import { Platform } from 'react-native';
+import { seedInitialData } from './seed';
+
+export type Database = SQLite.SQLiteDatabase;
+
+let dbInstance: Database | null = null;
+
+const migrations = [
+  `CREATE TABLE IF NOT EXISTS tascas (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    address TEXT NOT NULL,
+    city TEXT NOT NULL,
+    lat REAL NOT NULL,
+    lng REAL NOT NULL,
+    price_level INTEGER NOT NULL,
+    has_menu_of_day INTEGER NOT NULL,
+    accepts_cards INTEGER NOT NULL,
+    veg_options INTEGER NOT NULL,
+    gluten_free INTEGER NOT NULL,
+    tags_csv TEXT,
+    phone TEXT,
+    website TEXT,
+    menu_url TEXT,
+    schedule_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    pending_sync INTEGER NOT NULL DEFAULT 0
+  );`,
+  `CREATE TABLE IF NOT EXISTS reviews (
+    id TEXT PRIMARY KEY NOT NULL,
+    tasca_id TEXT NOT NULL,
+    user_nick TEXT NOT NULL,
+    comida REAL NOT NULL,
+    ambiente REAL NOT NULL,
+    preco_justo REAL NOT NULL,
+    comment TEXT,
+    created_at TEXT NOT NULL,
+    pending_sync INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (tasca_id) REFERENCES tascas(id) ON DELETE CASCADE
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_reviews_tasca ON reviews(tasca_id);`
+];
+
+const runMigrations = async (db: Database) => {
+  for (const query of migrations) {
+    await db.execAsync(query);
+  }
+};
+
+export const getDb = async () => {
+  if (!dbInstance) {
+    dbInstance = await SQLite.openDatabaseAsync('tascafinder.db');
+    await runMigrations(dbInstance);
+    await seedInitialData(dbInstance);
+  }
+  return dbInstance;
+};
+
+export const resetDatabase = async () => {
+  if (Platform.OS === 'web') return;
+  const db = await getDb();
+  await db.execAsync('DELETE FROM reviews;');
+  await db.execAsync('DELETE FROM tascas;');
+  await seedInitialData(db);
+};

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,0 +1,39 @@
+import { Linking, Platform } from 'react-native';
+
+const EARTH_RADIUS_KM = 6371;
+
+const toRad = (value: number) => (value * Math.PI) / 180;
+
+export const calculateDistanceKm = (
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+) => {
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+};
+
+export const openInMaps = async (lat: number, lng: number, name: string) => {
+  const label = encodeURIComponent(name);
+  const latLng = `${lat},${lng}`;
+  const iosUrl = `http://maps.apple.com/?q=${label}&ll=${latLng}`;
+  const googleUrl = `https://maps.google.com/?q=${label}&ll=${latLng}`;
+  const geoUrl = `geo:${latLng}?q=${latLng}(${label})`;
+  const scheme = Platform.select({ ios: iosUrl, android: geoUrl, default: googleUrl });
+  const fallback = Platform.OS === 'android' ? googleUrl : iosUrl;
+  const supported = await Linking.canOpenURL(scheme ?? googleUrl);
+  if (supported) {
+    await Linking.openURL(scheme ?? googleUrl);
+  } else {
+    await Linking.openURL(fallback);
+  }
+};

--- a/lib/repositories/reviewsRepo.ts
+++ b/lib/repositories/reviewsRepo.ts
@@ -1,0 +1,60 @@
+import { getDb } from '@/lib/db';
+
+export type Review = {
+  id: string;
+  tasca_id: string;
+  user_nick: string;
+  comida: number;
+  ambiente: number;
+  preco_justo: number;
+  comment: string;
+  created_at: string;
+  pending_sync: number;
+};
+
+export const getReviewsByTasca = async (tascaId: string) => {
+  const db = await getDb();
+  return db.getAllAsync<Review>(
+    'SELECT * FROM reviews WHERE tasca_id = ? ORDER BY created_at DESC',
+    [tascaId]
+  );
+};
+
+export const addReview = async (review: Review) => {
+  const db = await getDb();
+  await db.runAsync(
+    `INSERT INTO reviews (
+      id, tasca_id, user_nick, comida, ambiente, preco_justo, comment, created_at, pending_sync
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      review.id,
+      review.tasca_id,
+      review.user_nick,
+      review.comida,
+      review.ambiente,
+      review.preco_justo,
+      review.comment,
+      review.created_at,
+      review.pending_sync,
+    ]
+  );
+};
+
+export const getReviewStats = async (tascaId: string) => {
+  const db = await getDb();
+  return db.getFirstAsync<{
+    comida: number;
+    ambiente: number;
+    preco_justo: number;
+    reviews_count: number;
+  }>(
+    `SELECT
+      AVG(comida) as comida,
+      AVG(ambiente) as ambiente,
+      AVG(preco_justo) as preco_justo,
+      COUNT(*) as reviews_count
+    FROM reviews
+    WHERE tasca_id = ?`,
+    [tascaId]
+  );
+};

--- a/lib/repositories/tascasRepo.ts
+++ b/lib/repositories/tascasRepo.ts
@@ -1,0 +1,181 @@
+import { getDb } from '@/lib/db';
+import { calculateDistanceKm } from '@/lib/geo';
+import { computeScore } from '@/lib/repositories/utils';
+import { isOpen } from '@/lib/schedule';
+import { getReviewsByTasca } from './reviewsRepo';
+
+export type Tasca = {
+  id: string;
+  name: string;
+  address: string;
+  city: string;
+  lat: number;
+  lng: number;
+  price_level: number;
+  has_menu_of_day: number;
+  accepts_cards: number;
+  veg_options: number;
+  gluten_free: number;
+  tags_csv: string;
+  phone: string | null;
+  website: string | null;
+  menu_url: string | null;
+  schedule_json: string;
+  created_at: string;
+  updated_at: string;
+  pending_sync: number;
+};
+
+export type TascaWithScore = Tasca & {
+  score: number;
+  comida: number;
+  ambiente: number;
+  preco_justo: number;
+  reviews_count: number;
+  distanceKm?: number;
+};
+
+export const listTascas = async (options?: {
+  query?: string;
+  filters?: {
+    barato?: boolean;
+    menu?: boolean;
+    petiscos?: boolean;
+    comidaCaseira?: boolean;
+    abertoAgora?: boolean;
+  };
+  location?: { lat: number; lng: number } | null;
+  scheduleCheck?: Date;
+}) => {
+  const db = await getDb();
+  let sql = 'SELECT * FROM tascas';
+  const params: unknown[] = [];
+  if (options?.query) {
+    sql += ' WHERE name LIKE ? OR city LIKE ? OR address LIKE ?';
+    const wildcard = `%${options.query}%`;
+    params.push(wildcard, wildcard, wildcard);
+  }
+
+  const rows = await db.getAllAsync<Tasca>(sql, params);
+  const now = options?.scheduleCheck ?? new Date();
+  const results: TascaWithScore[] = [];
+
+  for (const row of rows) {
+    const reviews = await getReviewsByTasca(row.id);
+    const scoreInfo = computeScore(reviews);
+    const distanceKm = options?.location
+      ? calculateDistanceKm(options.location.lat, options.location.lng, row.lat, row.lng)
+      : undefined;
+
+    results.push({
+      ...row,
+      ...scoreInfo,
+      distanceKm,
+    });
+  }
+
+  let filtered = results;
+  if (options?.filters) {
+    const { barato, menu, petiscos, comidaCaseira, abertoAgora } = options.filters;
+    filtered = filtered.filter((tasca) => {
+      if (barato && tasca.price_level !== 1) return false;
+      if (menu && tasca.has_menu_of_day !== 1) return false;
+      const tags = tasca.tags_csv.toLowerCase();
+      if (petiscos && !tags.includes('petisco')) return false;
+      if (comidaCaseira && !tags.includes('caseir') && !tags.includes('tradicional')) {
+        return false;
+      }
+      if (abertoAgora) {
+        const schedule = JSON.parse(tasca.schedule_json);
+        if (!isOpen(schedule, now)) return false;
+      }
+      return true;
+    });
+  }
+
+  if (options?.location) {
+    filtered.sort((a, b) => (a.distanceKm ?? Infinity) - (b.distanceKm ?? Infinity));
+  } else {
+    filtered.sort((a, b) => b.score - a.score);
+  }
+
+  return filtered;
+};
+
+export const getTascaById = async (id: string, location?: { lat: number; lng: number } | null) => {
+  const db = await getDb();
+  const tasca = await db.getFirstAsync<Tasca>('SELECT * FROM tascas WHERE id = ?', [id]);
+  if (!tasca) return null;
+  const reviews = await getReviewsByTasca(id);
+  const scoreInfo = computeScore(reviews);
+  const distanceKm = location
+    ? calculateDistanceKm(location.lat, location.lng, tasca.lat, tasca.lng)
+    : undefined;
+
+  return {
+    ...tasca,
+    ...scoreInfo,
+    distanceKm,
+    reviews,
+  };
+};
+
+export const addTasca = async (data: {
+  id: string;
+  name: string;
+  address: string;
+  city: string;
+  lat: number;
+  lng: number;
+  price_level: number;
+  has_menu_of_day: number;
+  accepts_cards: number;
+  veg_options: number;
+  gluten_free: number;
+  tags_csv: string;
+  phone: string | null;
+  website: string | null;
+  menu_url: string | null;
+  schedule_json: string;
+  pending_sync: number;
+}) => {
+  const db = await getDb();
+  const now = new Date().toISOString();
+  await db.runAsync(
+    `INSERT INTO tascas (
+      id, name, address, city, lat, lng, price_level, has_menu_of_day,
+      accepts_cards, veg_options, gluten_free, tags_csv, phone, website, menu_url,
+      schedule_json, created_at, updated_at, pending_sync
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      data.id,
+      data.name,
+      data.address,
+      data.city,
+      data.lat,
+      data.lng,
+      data.price_level,
+      data.has_menu_of_day,
+      data.accepts_cards,
+      data.veg_options,
+      data.gluten_free,
+      data.tags_csv,
+      data.phone,
+      data.website,
+      data.menu_url,
+      data.schedule_json,
+      now,
+      now,
+      data.pending_sync,
+    ]
+  );
+};
+
+export const searchSuggestions = async (query: string) => {
+  const db = await getDb();
+  const wildcard = `%${query}%`;
+  return db.getAllAsync<{ id: string; name: string }>(
+    'SELECT id, name FROM tascas WHERE name LIKE ? LIMIT 10',
+    [wildcard]
+  );
+};

--- a/lib/repositories/utils.ts
+++ b/lib/repositories/utils.ts
@@ -1,0 +1,37 @@
+import { Review } from './reviewsRepo';
+
+export const computeScore = (reviews: Review[]) => {
+  if (reviews.length === 0) {
+    return {
+      score: 0,
+      comida: 0,
+      ambiente: 0,
+      preco_justo: 0,
+      reviews_count: 0,
+    };
+  }
+
+  const totals = reviews.reduce(
+    (acc, review) => {
+      acc.comida += review.comida;
+      acc.ambiente += review.ambiente;
+      acc.preco_justo += review.preco_justo;
+      return acc;
+    },
+    { comida: 0, ambiente: 0, preco_justo: 0 }
+  );
+
+  const comida = totals.comida / reviews.length;
+  const ambiente = totals.ambiente / reviews.length;
+  const preco = totals.preco_justo / reviews.length;
+  const weighted = comida * 0.5 + ambiente * 0.3 + preco * 0.2;
+  const score = Math.round(weighted * 10) / 10;
+
+  return {
+    score,
+    comida: Math.round(comida * 10) / 10,
+    ambiente: Math.round(ambiente * 10) / 10,
+    preco_justo: Math.round(preco * 10) / 10,
+    reviews_count: reviews.length,
+  };
+};

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -1,0 +1,34 @@
+export type DailySchedule = [string, string][];
+export type WeeklySchedule = Record<string, DailySchedule>;
+
+const weekdayMap = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+const parseTime = (time: string) => {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+export const isOpen = (schedule: WeeklySchedule, referenceDate: Date = new Date()) => {
+  const dayKey = weekdayMap[referenceDate.getDay()];
+  const today = schedule[dayKey] ?? [];
+  if (today.length === 0) {
+    return false;
+  }
+  const minutes = referenceDate.getHours() * 60 + referenceDate.getMinutes();
+  return today.some(([start, end]) => {
+    const startMinutes = parseTime(start);
+    const endMinutes = parseTime(end);
+    if (endMinutes < startMinutes) {
+      return minutes >= startMinutes || minutes <= endMinutes;
+    }
+    return minutes >= startMinutes && minutes <= endMinutes;
+  });
+};
+
+export const todaysSchedule = (schedule: WeeklySchedule, referenceDate: Date = new Date()) => {
+  const dayKey = weekdayMap[referenceDate.getDay()];
+  return schedule[dayKey] ?? [];
+};
+
+export const formatScheduleRange = (range: DailySchedule) =>
+  range.map(([start, end]) => `${start}–${end}`).join(', ');

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -1,0 +1,706 @@
+import { Database } from './db';
+import { v4 as uuidv4 } from 'uuid';
+
+const nowIso = () => new Date().toISOString();
+
+type SeedTasca = {
+  name: string;
+  address: string;
+  city: string;
+  lat: number;
+  lng: number;
+  price_level: 1 | 2 | 3;
+  has_menu_of_day: boolean;
+  accepts_cards: boolean;
+  veg_options: boolean;
+  gluten_free: boolean;
+  tags: string[];
+  phone?: string;
+  website?: string;
+  menu_url?: string;
+  schedule: Record<string, [string, string][]>;
+  reviews: Array<{
+    user_nick: string;
+    comida: number;
+    ambiente: number;
+    preco_justo: number;
+    comment: string;
+  }>;
+};
+
+const tascaSeeds: SeedTasca[] = [
+  {
+    name: 'A Tasquinha do Fado',
+    address: 'Rua da Mouraria 15',
+    city: 'Lisboa',
+    lat: 38.7133,
+    lng: -9.1325,
+    price_level: 2,
+    has_menu_of_day: true,
+    accepts_cards: true,
+    veg_options: false,
+    gluten_free: false,
+    tags: ['bacalhau', 'fado', 'caldo verde'],
+    phone: '+351210000111',
+    website: 'https://atasquinhadofado.pt',
+    menu_url: 'https://atasquinhadofado.pt/menu',
+    schedule: {
+      mon: [
+        ['12:00', '15:00'],
+        ['19:00', '23:00'],
+      ],
+      tue: [
+        ['12:00', '15:00'],
+        ['19:00', '23:00'],
+      ],
+      wed: [
+        ['12:00', '15:00'],
+        ['19:00', '23:00'],
+      ],
+      thu: [
+        ['12:00', '15:00'],
+        ['19:00', '23:00'],
+      ],
+      fri: [
+        ['12:00', '15:00'],
+        ['19:00', '23:30'],
+      ],
+      sat: [
+        ['12:30', '16:00'],
+        ['19:00', '23:30'],
+      ],
+      sun: [
+        ['12:30', '16:00'],
+      ],
+    },
+    reviews: [
+      {
+        user_nick: 'LisboetaAntigo',
+        comida: 4.5,
+        ambiente: 5,
+        preco_justo: 4,
+        comment: 'Fado ao vivo e bacalhau à lagareiro impecável.',
+      },
+      {
+        user_nick: 'ViagemComSabores',
+        comida: 4,
+        ambiente: 4.5,
+        preco_justo: 3.5,
+        comment: 'Carta tradicional com petiscos ricos, staff acolhedor.',
+      },
+    ],
+  },
+  {
+    name: 'Casa das Iscas',
+    address: 'Rua dos Sapateiros 92',
+    city: 'Lisboa',
+    lat: 38.7099,
+    lng: -9.1361,
+    price_level: 1,
+    has_menu_of_day: true,
+    accepts_cards: false,
+    veg_options: false,
+    gluten_free: false,
+    tags: ['iscas', 'petiscos', 'grelhados'],
+    schedule: {
+      mon: [
+        ['11:30', '15:30'],
+      ],
+      tue: [
+        ['11:30', '15:30'],
+      ],
+      wed: [
+        ['11:30', '15:30'],
+      ],
+      thu: [
+        ['11:30', '15:30'],
+      ],
+      fri: [
+        ['11:30', '15:30'],
+      ],
+      sat: [
+        ['12:00', '16:00'],
+      ],
+      sun: [],
+    },
+    reviews: [
+      {
+        user_nick: 'ComedorDeIscas',
+        comida: 4.8,
+        ambiente: 3.8,
+        preco_justo: 5,
+        comment: 'Iscas no ponto e vinho a copo barato, típico.',
+      },
+      {
+        user_nick: 'TascaHunter',
+        comida: 4,
+        ambiente: 3.5,
+        preco_justo: 4.5,
+        comment: 'Serviço rápido, menu do dia sempre fresco.',
+      },
+    ],
+  },
+  {
+    name: 'Adega São Nicolau',
+    address: 'Rua de São Nicolau 1',
+    city: 'Porto',
+    lat: 41.1401,
+    lng: -8.6115,
+    price_level: 2,
+    has_menu_of_day: false,
+    accepts_cards: true,
+    veg_options: false,
+    gluten_free: false,
+    tags: ['tripas', 'bacalhau', 'vinho verde'],
+    phone: '+351222005522',
+    schedule: {
+      mon: [
+        ['12:00', '15:30'],
+        ['19:00', '22:30'],
+      ],
+      tue: [
+        ['12:00', '15:30'],
+        ['19:00', '22:30'],
+      ],
+      wed: [
+        ['12:00', '15:30'],
+        ['19:00', '22:30'],
+      ],
+      thu: [
+        ['12:00', '15:30'],
+        ['19:00', '22:30'],
+      ],
+      fri: [
+        ['12:00', '15:30'],
+        ['19:00', '23:00'],
+      ],
+      sat: [
+        ['12:00', '16:00'],
+        ['19:00', '23:00'],
+      ],
+      sun: [],
+    },
+    reviews: [
+      {
+        user_nick: 'TripeiroFeliz',
+        comida: 4.7,
+        ambiente: 4.4,
+        preco_justo: 3.8,
+        comment: 'Tripas com sabor autêntico, carta de vinhos excelente.',
+      },
+      {
+        user_nick: 'DocesRabelos',
+        comida: 4.3,
+        ambiente: 4.2,
+        preco_justo: 3.5,
+        comment: 'Francesinha diferente mas saborosa, atendimento caloroso.',
+      },
+    ],
+  },
+  {
+    name: 'Taberna Santo António',
+    address: 'Rua das Virtudes 32',
+    city: 'Porto',
+    lat: 41.1448,
+    lng: -8.6174,
+    price_level: 1,
+    has_menu_of_day: true,
+    accepts_cards: true,
+    veg_options: true,
+    gluten_free: false,
+    tags: ['rojões', 'pataniscas', 'vinho do porto'],
+    schedule: {
+      mon: [
+        ['12:00', '15:30'],
+      ],
+      tue: [
+        ['12:00', '15:30'],
+      ],
+      wed: [
+        ['12:00', '15:30'],
+      ],
+      thu: [
+        ['12:00', '15:30'],
+      ],
+      fri: [
+        ['12:00', '15:30'],
+        ['19:00', '22:00'],
+      ],
+      sat: [
+        ['12:00', '16:00'],
+      ],
+      sun: [],
+    },
+    reviews: [
+      {
+        user_nick: 'BifanaFan',
+        comida: 4.2,
+        ambiente: 4.6,
+        preco_justo: 4.9,
+        comment: 'Vista linda para o Douro, prato do dia generoso.',
+      },
+      {
+        user_nick: 'RibeiraWalks',
+        comida: 4,
+        ambiente: 4.5,
+        preco_justo: 4.2,
+        comment: 'Petiscos variados, ambiente familiar.',
+      },
+    ],
+  },
+  {
+    name: 'Cantinho Minhoto',
+    address: 'Largo São João do Souto 5',
+    city: 'Braga',
+    lat: 41.5494,
+    lng: -8.4276,
+    price_level: 2,
+    has_menu_of_day: true,
+    accepts_cards: true,
+    veg_options: true,
+    gluten_free: true,
+    tags: ['bacalhau', 'rojões', 'papas de sarrabulho'],
+    schedule: {
+      mon: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      tue: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      wed: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      thu: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      fri: [
+        ['12:00', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      sat: [
+        ['12:30', '16:00'],
+        ['19:00', '22:30'],
+      ],
+      sun: [
+        ['12:30', '16:00'],
+      ],
+    },
+    reviews: [
+      {
+        user_nick: 'MinhotoDeRaiz',
+        comida: 4.6,
+        ambiente: 4.1,
+        preco_justo: 4,
+        comment: 'Papas de sarrabulho ricas e atendimento muito próximo.',
+      },
+      {
+        user_nick: 'DestinosDoNorte',
+        comida: 4.3,
+        ambiente: 4.2,
+        preco_justo: 4.1,
+        comment: 'Carta tradicional com opção vegetariana surpreendente.',
+      },
+    ],
+  },
+  {
+    name: 'Taberna do Largo',
+    address: 'Largo da Sé Velha 8',
+    city: 'Coimbra',
+    lat: 40.2084,
+    lng: -8.4286,
+    price_level: 2,
+    has_menu_of_day: false,
+    accepts_cards: true,
+    veg_options: false,
+    gluten_free: false,
+    tags: ['chanfana', 'queijo da serra', 'caldo verde'],
+    schedule: {
+      mon: [
+        ['12:30', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      tue: [
+        ['12:30', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      wed: [
+        ['12:30', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      thu: [
+        ['12:30', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      fri: [
+        ['12:30', '15:00'],
+        ['19:00', '23:30'],
+      ],
+      sat: [
+        ['12:30', '16:00'],
+        ['19:00', '23:30'],
+      ],
+      sun: [],
+    },
+    reviews: [
+      {
+        user_nick: 'CoimbraSempre',
+        comida: 4.5,
+        ambiente: 4.2,
+        preco_justo: 3.9,
+        comment: 'Chanfana incrível, carta de vinhos cuidada.',
+      },
+      {
+        user_nick: 'EstudanteSaudosista',
+        comida: 4.1,
+        ambiente: 4.3,
+        preco_justo: 3.8,
+        comment: 'Ambiente histórico, serviço simpático.',
+      },
+    ],
+  },
+  {
+    name: 'Botequim da Mouraria',
+    address: 'Rua Diogo Lopes de Sequeira 2',
+    city: 'Évora',
+    lat: 38.5717,
+    lng: -7.9087,
+    price_level: 2,
+    has_menu_of_day: true,
+    accepts_cards: true,
+    veg_options: true,
+    gluten_free: false,
+    tags: ['açorda', 'ensopado de borrego', 'vinhos alentejanos'],
+    schedule: {
+      mon: [
+        ['12:00', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      tue: [
+        ['12:00', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      wed: [
+        ['12:00', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      thu: [
+        ['12:00', '15:00'],
+        ['19:00', '22:30'],
+      ],
+      fri: [
+        ['12:00', '15:00'],
+        ['19:00', '23:00'],
+      ],
+      sat: [
+        ['12:30', '16:00'],
+        ['19:00', '23:00'],
+      ],
+      sun: [
+        ['12:30', '16:00'],
+      ],
+    },
+    reviews: [
+      {
+        user_nick: 'AlentejoGourmet',
+        comida: 4.8,
+        ambiente: 4.4,
+        preco_justo: 4,
+        comment: 'Ensopado generoso, carta de vinhos alentejanos excelente.',
+      },
+      {
+        user_nick: 'RotaDoVinho',
+        comida: 4.2,
+        ambiente: 4.1,
+        preco_justo: 3.9,
+        comment: 'Staff acolhedor, petiscos variados.',
+      },
+    ],
+  },
+  {
+    name: 'Tasquinha do Rossio',
+    address: 'Praça do Rossio 14',
+    city: 'Faro',
+    lat: 37.0179,
+    lng: -7.9351,
+    price_level: 1,
+    has_menu_of_day: true,
+    accepts_cards: false,
+    veg_options: true,
+    gluten_free: false,
+    tags: ['cataplana', 'peixe fresco', 'dieta mediterrânica'],
+    schedule: {
+      mon: [
+        ['12:00', '15:30'],
+        ['19:00', '22:00'],
+      ],
+      tue: [
+        ['12:00', '15:30'],
+        ['19:00', '22:00'],
+      ],
+      wed: [
+        ['12:00', '15:30'],
+        ['19:00', '22:00'],
+      ],
+      thu: [
+        ['12:00', '15:30'],
+        ['19:00', '22:00'],
+      ],
+      fri: [
+        ['12:00', '15:30'],
+        ['19:00', '22:30'],
+      ],
+      sat: [
+        ['12:00', '16:00'],
+        ['19:00', '22:30'],
+      ],
+      sun: [
+        ['12:30', '16:00'],
+      ],
+    },
+    reviews: [
+      {
+        user_nick: 'MarisqueiroAlgarvio',
+        comida: 4.5,
+        ambiente: 4.1,
+        preco_justo: 4.6,
+        comment: 'Cataplana rica e peixe muito fresco.',
+      },
+      {
+        user_nick: 'PraiaPetisqueira',
+        comida: 4.1,
+        ambiente: 3.9,
+        preco_justo: 4.4,
+        comment: 'Menu do dia excelente, serviço rápido.',
+      },
+    ],
+  },
+  {
+    name: 'Adega do Rocha',
+    address: 'Rua da Sofia 120',
+    city: 'Coimbra',
+    lat: 40.2042,
+    lng: -8.4303,
+    price_level: 1,
+    has_menu_of_day: true,
+    accepts_cards: true,
+    veg_options: false,
+    gluten_free: false,
+    tags: ['chanfana', 'leitão', 'arroz de lampreia'],
+    schedule: {
+      mon: [
+        ['12:00', '15:00'],
+      ],
+      tue: [
+        ['12:00', '15:00'],
+      ],
+      wed: [
+        ['12:00', '15:00'],
+      ],
+      thu: [
+        ['12:00', '15:00'],
+      ],
+      fri: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      sat: [
+        ['12:00', '16:00'],
+      ],
+      sun: [],
+    },
+    reviews: [
+      {
+        user_nick: 'LampreiaLover',
+        comida: 4.4,
+        ambiente: 3.9,
+        preco_justo: 4.5,
+        comment: 'Arroz de lampreia tradicionalíssimo e barato.',
+      },
+      {
+        user_nick: 'SaboresDaBaixa',
+        comida: 4.1,
+        ambiente: 3.8,
+        preco_justo: 4.2,
+        comment: 'Menu do dia sempre farto.',
+      },
+    ],
+  },
+  {
+    name: 'Tasca da Sé',
+    address: 'Rua Dom Paio Mendes 58',
+    city: 'Braga',
+    lat: 41.551,
+    lng: -8.4271,
+    price_level: 2,
+    has_menu_of_day: true,
+    accepts_cards: true,
+    veg_options: true,
+    gluten_free: true,
+    tags: ['pataniscas', 'bacalhau', 'arroz de pato'],
+    schedule: {
+      mon: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      tue: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      wed: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      thu: [
+        ['12:00', '15:00'],
+        ['19:00', '22:00'],
+      ],
+      fri: [
+        ['12:00', '15:00'],
+        ['19:00', '23:00'],
+      ],
+      sat: [
+        ['12:30', '16:00'],
+        ['19:00', '23:00'],
+      ],
+      sun: [],
+    },
+    reviews: [
+      {
+        user_nick: 'PataniscasQueen',
+        comida: 4.6,
+        ambiente: 4.3,
+        preco_justo: 4,
+        comment: 'Pataniscas crocantes e arroz malandrinho.',
+      },
+      {
+        user_nick: 'TuristaCurioso',
+        comida: 4.2,
+        ambiente: 4.4,
+        preco_justo: 3.9,
+        comment: 'Staff super simpático, bom vinho verde.',
+      },
+    ],
+  },
+  {
+    name: 'Tasquinha do Olival',
+    address: 'Rua do Olival 72',
+    city: 'Porto',
+    lat: 41.1432,
+    lng: -8.6215,
+    price_level: 2,
+    has_menu_of_day: false,
+    accepts_cards: true,
+    veg_options: true,
+    gluten_free: false,
+    tags: ['petiscos', 'enchidos', 'vinho do Douro'],
+    schedule: {
+      mon: [
+        ['12:30', '15:00'],
+        ['19:00', '23:30'],
+      ],
+      tue: [
+        ['12:30', '15:00'],
+        ['19:00', '23:30'],
+      ],
+      wed: [
+        ['12:30', '15:00'],
+        ['19:00', '23:30'],
+      ],
+      thu: [
+        ['12:30', '15:00'],
+        ['19:00', '23:30'],
+      ],
+      fri: [
+        ['12:30', '15:00'],
+        ['19:00', '00:00'],
+      ],
+      sat: [
+        ['12:30', '16:00'],
+        ['19:00', '00:00'],
+      ],
+      sun: [
+        ['12:30', '16:00'],
+      ],
+    },
+    reviews: [
+      {
+        user_nick: 'EnchidosPower',
+        comida: 4.5,
+        ambiente: 4.7,
+        preco_justo: 4,
+        comment: 'Tábuas de enchidos fantásticas e grandes vinhos.',
+      },
+      {
+        user_nick: 'NoiteDoPorto',
+        comida: 4.1,
+        ambiente: 4.6,
+        preco_justo: 3.8,
+        comment: 'Ótimo para petiscar com amigos, ambiente animado.',
+      },
+    ],
+  },
+];
+
+export const seedInitialData = async (db: Database) => {
+  const tascasCount = await db.getFirstAsync<{ count: number }>(
+    'SELECT COUNT(*) as count FROM tascas'
+  );
+  if (tascasCount && tascasCount.count > 0) {
+    return;
+  }
+
+  for (const tasca of tascaSeeds) {
+    const tascaId = uuidv4();
+    const createdAt = nowIso();
+    await db.runAsync(
+      `INSERT INTO tascas (
+        id, name, address, city, lat, lng, price_level,
+        has_menu_of_day, accepts_cards, veg_options, gluten_free,
+        tags_csv, phone, website, menu_url, schedule_json, created_at, updated_at, pending_sync
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        tascaId,
+        tasca.name,
+        tasca.address,
+        tasca.city,
+        tasca.lat,
+        tasca.lng,
+        tasca.price_level,
+        tasca.has_menu_of_day ? 1 : 0,
+        tasca.accepts_cards ? 1 : 0,
+        tasca.veg_options ? 1 : 0,
+        tasca.gluten_free ? 1 : 0,
+        tasca.tags.join(', '),
+        tasca.phone ?? null,
+        tasca.website ?? null,
+        tasca.menu_url ?? null,
+        JSON.stringify(tasca.schedule),
+        createdAt,
+        createdAt,
+        0,
+      ]
+    );
+
+    for (const review of tasca.reviews) {
+      await db.runAsync(
+        `INSERT INTO reviews (
+          id, tasca_id, user_nick, comida, ambiente, preco_justo, comment, created_at, pending_sync
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+        [
+          uuidv4(),
+          tascaId,
+          review.user_nick,
+          review.comida,
+          review.ambiente,
+          review.preco_justo,
+          review.comment,
+          nowIso(),
+        ]
+      );
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "tasca-finder",
+  "version": "1.0.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "dev": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "seed": "ts-node -r tsconfig-paths/register scripts/seed.ts",
+    "test": "ts-node -r tsconfig-paths/register tests/run.ts"
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.19.0",
+    "@types/uuid": "^9.0.7",
+    "expo": "~50.0.16",
+    "expo-location": "~15.3.1",
+    "expo-linear-gradient": "~13.3.1",
+    "expo-router": "~3.4.8",
+    "expo-secure-store": "~13.5.1",
+    "expo-sqlite": "~13.3.1",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.50.0",
+    "react-native": "0.73.6",
+    "react-native-gesture-handler": "~2.14.0",
+    "react-native-reanimated": "~3.6.2",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@types/react": "~18.2.45",
+    "@types/react-native": "^0.73.0",
+    "@typescript-eslint/eslint-plugin": "^6.17.0",
+    "@typescript-eslint/parser": "^6.17.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.1.1",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,9 @@
+import { getDb, resetDatabase } from '@/lib/db';
+
+(async () => {
+  await resetDatabase();
+  console.log('Database reseeded with demo data.');
+  const db = await getDb();
+  const count = await db.getFirstAsync<{ count: number }>('SELECT COUNT(*) as count FROM tascas');
+  console.log(`Tascas disponíveis: ${count?.count ?? 0}`);
+})();

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -1,0 +1,53 @@
+import { create } from 'zustand';
+
+export type FiltersState = {
+  barato: boolean;
+  menu: boolean;
+  petiscos: boolean;
+  comidaCaseira: boolean;
+  abertoAgora: boolean;
+};
+
+export type LocationState = {
+  coords: { lat: number; lng: number } | null;
+  permissionStatus: 'unknown' | 'granted' | 'denied';
+};
+
+export type AppState = {
+  filters: FiltersState;
+  location: LocationState;
+  query: string;
+  setQuery: (value: string) => void;
+  toggleFilter: (filter: keyof FiltersState) => void;
+  resetFilters: () => void;
+  setLocation: (coords: { lat: number; lng: number } | null) => void;
+  setPermissionStatus: (status: LocationState['permissionStatus']) => void;
+};
+
+const defaultFilters: FiltersState = {
+  barato: false,
+  menu: false,
+  petiscos: false,
+  comidaCaseira: false,
+  abertoAgora: false,
+};
+
+export const useAppStore = create<AppState>((set) => ({
+  filters: { ...defaultFilters },
+  location: { coords: null, permissionStatus: 'unknown' },
+  query: '',
+  setQuery: (value) => set({ query: value }),
+  toggleFilter: (filter) =>
+    set((state) => ({
+      filters: { ...state.filters, [filter]: !state.filters[filter] },
+    })),
+  resetFilters: () => set({ filters: { ...defaultFilters } }),
+  setLocation: (coords) =>
+    set((state) => ({
+      location: { ...state.location, coords },
+    })),
+  setPermissionStatus: (status) =>
+    set((state) => ({
+      location: { ...state.location, permissionStatus: status },
+    })),
+}));

--- a/tests/geo.test.ts
+++ b/tests/geo.test.ts
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import { calculateDistanceKm } from '@/lib/geo';
+
+export const runGeoTests = () => {
+  const lisbon = { lat: 38.7223, lng: -9.1393 };
+  const porto = { lat: 41.1579, lng: -8.6291 };
+  const distance = calculateDistanceKm(lisbon.lat, lisbon.lng, porto.lat, porto.lng);
+  assert(distance > 270 && distance < 320, 'Distância Lisboa-Porto deve ficar entre 270km e 320km');
+
+  const same = calculateDistanceKm(lisbon.lat, lisbon.lng, lisbon.lat, lisbon.lng);
+  assert(Math.abs(same) < 0.01, 'Distância para o mesmo ponto deve ser ~0');
+};

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -1,0 +1,11 @@
+import { runGeoTests } from './geo.test';
+import { runScheduleTests } from './schedule.test';
+
+try {
+  runGeoTests();
+  runScheduleTests();
+  console.log('✅ Todos os testes passaram');
+} catch (error) {
+  console.error('❌ Falha nos testes:', error);
+  process.exit(1);
+}

--- a/tests/schedule.test.ts
+++ b/tests/schedule.test.ts
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { isOpen, formatScheduleRange, todaysSchedule } from '@/lib/schedule';
+
+export const runScheduleTests = () => {
+  const schedule = {
+    mon: [
+      ['12:00', '15:00'],
+      ['19:00', '22:00'],
+    ],
+    tue: [],
+    wed: [['10:00', '02:00']],
+  };
+
+  const mondayLunch = new Date('2024-01-01T13:00:00');
+  assert(isOpen(schedule, mondayLunch), 'Deve estar aberto na hora de almoço de segunda-feira');
+
+  const mondayNight = new Date('2024-01-01T23:30:00');
+  assert(!isOpen(schedule, mondayNight), 'Deve fechar após as 22h de segunda-feira');
+
+  const wednesdayLate = new Date('2024-01-03T01:30:00');
+  assert(isOpen(schedule, wednesdayLate), 'Faixa que atravessa a meia-noite deve ser reconhecida.');
+
+  const todayRange = todaysSchedule(schedule, new Date('2024-01-01T08:00:00'));
+  assert(formatScheduleRange(todayRange) === '12:00–15:00, 19:00–22:00', 'Formato de horário deve usar separador EN dash.');
+};

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -1,0 +1,13 @@
+export const colors = {
+  azulejo: '#0D3B66',
+  branco: '#FFFFFF',
+  bege: '#F4EFE6',
+  vinho: '#8B0000',
+  verde: '#0F5D3F',
+  cinzaTexto: '#444444',
+  cinzaMedio: '#7A7A7A',
+  cinzaClaro: '#D9D9D9',
+  sombra: 'rgba(13, 59, 102, 0.2)',
+};
+
+export type ColorName = keyof typeof colors;

--- a/theme/shadows.ts
+++ b/theme/shadows.ts
@@ -1,0 +1,11 @@
+import { colors } from './colors';
+
+export const shadows = {
+  card: {
+    shadowColor: colors.azulejo,
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 3,
+  },
+};

--- a/theme/spacing.ts
+++ b/theme/spacing.ts
@@ -1,0 +1,10 @@
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
+};
+
+export type SpacingToken = keyof typeof spacing;

--- a/theme/tiles.ts
+++ b/theme/tiles.ts
@@ -1,0 +1,28 @@
+import { colors } from './colors';
+
+export const tileStyles = {
+  container: {
+    borderWidth: 2,
+    borderColor: colors.azulejo,
+    backgroundColor: colors.bege,
+    borderRadius: 12,
+  },
+  header: {
+    backgroundColor: colors.azulejo,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+  },
+  headerText: {
+    color: colors.branco,
+    fontSize: 22,
+    fontWeight: '700' as const,
+    textAlign: 'center' as const,
+  },
+  subheaderText: {
+    color: colors.bege,
+    fontSize: 14,
+    textAlign: 'center' as const,
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/store/*": ["store/*"],
+      "@/theme/*": ["theme/*"],
+      "@/utils/*": ["utils/*"],
+      "@/app/*": ["app/*"]
+    }
+  }
+}

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -1,0 +1,28 @@
+import { colors } from '@/theme/colors';
+
+type PriceLevel = 1 | 2 | 3;
+
+export const formatPriceLevel = (level: PriceLevel) => {
+  return '€'.repeat(level);
+};
+
+export const formatDistance = (distanceKm: number) => {
+  if (distanceKm < 1) {
+    return `${Math.round(distanceKm * 1000)} m`;
+  }
+  return `${distanceKm.toFixed(1)} km`;
+};
+
+export const formatScore = (score: number) => score.toFixed(1);
+
+export const badgeBackground = (active: boolean) =>
+  active ? colors.azulejo : colors.bege;
+
+export const badgeText = (active: boolean) =>
+  active ? colors.branco : colors.azulejo;
+
+export const capitalize = (text: string) =>
+  text
+    .split(' ')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');

--- a/utils/validate.ts
+++ b/utils/validate.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const tascaSchema = z.object({
+  name: z.string().min(3),
+  address: z.string().min(5),
+  city: z.string().min(2),
+  lat: z.coerce.number().min(-90).max(90),
+  lng: z.coerce.number().min(-180).max(180),
+  price_level: z.coerce.number().min(1).max(3),
+  has_menu_of_day: z.boolean(),
+  accepts_cards: z.boolean(),
+  veg_options: z.boolean(),
+  gluten_free: z.boolean(),
+  tags_csv: z.string().optional().default(''),
+  phone: z.string().optional().nullable(),
+  website: z.string().url().optional().nullable(),
+  menu_url: z.string().url().optional().nullable(),
+});
+
+export const reviewSchema = z.object({
+  tasca_id: z.string().uuid(),
+  user_nick: z.string().min(2),
+  comida: z.coerce.number().min(0).max(5),
+  ambiente: z.coerce.number().min(0).max(5),
+  preco_justo: z.coerce.number().min(0).max(5),
+  comment: z.string().max(280).optional().default(''),
+});


### PR DESCRIPTION
## Summary
- create Expo Router project structure with Portuguese tile-inspired theming, reusable components, and ad placeholder widgets
- add SQLite persistence with seed data, repositories, geolocation utilities, and scoring helpers for tasca listings and reviews
- implement core screens for home, tasca details, roteiros, profile, and forms to add new tascas or reviews using react-hook-form and zod

## Testing
- not run (not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd124c6d48331a8b7bdaaf554d31c