### PR TITLE
chore: bump expo-linear-gradient to ~13.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/uuid": "^9.0.7",
     "expo": "~50.0.16",
     "expo-location": "~15.3.1",
-    "expo-linear-gradient": "~13.3.1",
+    "expo-linear-gradient": "~13.4.0",
     "expo-router": "~3.4.8",
     "expo-secure-store": "~13.5.1",
     "expo-sqlite": "~13.3.1",


### PR DESCRIPTION
## Summary
- update expo-linear-gradient dependency to the SDK 50-compatible ~13.4.0 release

## Testing
- npm install *(fails: 403 Forbidden from registry)*
- yarn install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd936b12483319fd6a45b4e465436